### PR TITLE
RWMutex initial

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -28,6 +28,7 @@ rules:
       case: { after: true }
     }
   }]
+  no-constant-condition: ["error", {"checkLoops": false}]
   no-labels: [2, { allowLoop: false, allowSwitch: false }]
   no-unused-vars: ["error", { "argsIgnorePattern": "next" }]
   no-param-reassign: 0 # Add back with exceptions when https://github.com/eslint/eslint/issues/6505 is resolved

--- a/__mocks__/MockCollection.ts
+++ b/__mocks__/MockCollection.ts
@@ -1,0 +1,20 @@
+function cursor() {
+  const j = jest.fn();
+  j.limit = jest.fn(() => j);
+  j.next = jest.fn(() => Promise.resolve(null));
+  return j;
+}
+
+export default class MockCollection {
+  _cursor;
+  find;
+  insert;
+  updateOne;
+
+  constructor() {
+    this._cursor = cursor();
+    this.find = jest.fn(() => this._cursor);
+    this.insert = jest.fn(() => Promise.resolve({ matchedCount: 1 }));
+    this.updateOne = jest.fn(() => Promise.resolve({ matchedCount: 1 }));
+  }
+}

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -115,7 +115,7 @@ describe("RWMutex", () => {
       try {
         await lock.unlock();
       } catch (err) {
-        expect(err.message).toBe("lock not currently held by client: 1");
+        expect(err.message).toBe("lock lockID not currently held by client: 1");
         expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
         expect(mockCollection.updateOne).toHaveBeenCalledWith({
           lockID,
@@ -236,7 +236,7 @@ describe("RWMutex", () => {
       try {
         await lock.rUnlock();
       } catch (err) {
-        expect(err.message).toBe("lock not currently held by client: 1");
+        expect(err.message).toBe("lock lockID not currently held by client: 1");
         expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
         expect(mockCollection.updateOne).toHaveBeenCalledWith({
           lockID,

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -1,0 +1,254 @@
+import RWMutex from "../lib/RWMutex";
+import MockCollection from "../__mocks__/MockCollection";
+
+// ---------- Defaults ----------
+const lockID = "lockID";
+const clientID = "1";
+
+// ---------- Tests ----------
+describe("RWMutex", () => {
+  describe(".lock()", () => {
+    it("acquires the lock", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection._cursor.next = jest.fn()
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "" }));
+      const lock = new RWMutex(mockCollection, lockID, clientID);
+      await lock.lock();
+
+      expect(mockCollection.find).toHaveBeenCalledWith({ lockID });
+      expect(mockCollection.updateOne).toHaveBeenCalledWith({
+        lockID,
+        readers: [],
+        writer: "",
+      }, {
+        $set: {
+          writer: "1",
+        },
+      });
+    });
+
+    it("inserts a lock if none exists", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection._cursor.next = jest.fn()
+        .mockReturnValueOnce(Promise.resolve(null))
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "" }));
+      const lock = new RWMutex(mockCollection, lockID, clientID);
+      await lock.lock();
+
+      expect(mockCollection.find).toHaveBeenCalledWith({ lockID });
+      expect(mockCollection.insert).toHaveBeenCalledWith({
+        lockID,
+        readers: [],
+        writer: "",
+      });
+      expect(mockCollection.updateOne).toHaveBeenCalledWith({
+        lockID,
+        readers: [],
+        writer: "",
+      }, {
+        $set: {
+          writer: "1",
+        },
+      });
+    });
+
+    it("waits if the lock is already in use", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection._cursor.next = jest.fn()
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "different" }));
+      mockCollection.updateOne = jest.fn()
+        .mockReturnValueOnce(Promise.resolve({ matchedCount: 0 }))
+        .mockReturnValueOnce(Promise.resolve({ matchedCount: 1 }));
+      const lock = new RWMutex(mockCollection, lockID, clientID, { sleepTime: 1 });
+      await lock.lock();
+
+      expect(mockCollection.find).toHaveBeenCalledTimes(1);
+      expect(mockCollection.find).toHaveBeenCalledWith({ lockID });
+      expect(mockCollection.updateOne).toHaveBeenCalledTimes(2);
+      expect(mockCollection.updateOne).toHaveBeenCalledWith({
+        lockID,
+        readers: [],
+        writer: "",
+      }, {
+        $set: {
+          writer: "1",
+        },
+      });
+    });
+
+    it("re-enters the lock if the client id already has the lock", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection._cursor.next = jest.fn()
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: clientID }));
+      const lock = new RWMutex(mockCollection, lockID, clientID, { sleepTime: 1 });
+      await lock.lock();
+
+      expect(mockCollection.find).toHaveBeenCalledTimes(1);
+      expect(mockCollection.find).toHaveBeenCalledWith({ lockID });
+      expect(mockCollection.insert).toHaveBeenCalledTimes(0);
+      expect(mockCollection.updateOne).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe(".unlock()", () => {
+    it("releases the lock", async () => {
+      const mockCollection = new MockCollection();
+      const lock = new RWMutex(mockCollection, lockID, clientID);
+      await lock.unlock();
+
+      expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
+      expect(mockCollection.updateOne).toHaveBeenCalledWith({
+        lockID,
+        writer: clientID,
+      }, {
+        $set: {
+          writer: "",
+        },
+      });
+    });
+
+    it("returns an error if the client did not hold the lock", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection.updateOne = jest.fn().mockReturnValue(Promise.resolve({ matchedCount: 0 }));
+      const lock = new RWMutex(mockCollection, lockID, clientID);
+
+      try {
+        await lock.unlock();
+      } catch (err) {
+        expect(err.message).toBe("lock not currently held by client: 1");
+        expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
+        expect(mockCollection.updateOne).toHaveBeenCalledWith({
+          lockID,
+          writer: clientID,
+        }, {
+          $set: {
+            writer: "",
+          },
+        });
+        return;
+      }
+      throw new Error("expected unlock to error");
+    });
+  });
+
+  describe(".rLock()", () => {
+    it("acquires the lock", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection._cursor.next = jest.fn()
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "" }));
+      const lock = new RWMutex(mockCollection, lockID, clientID);
+      await lock.rLock();
+
+      expect(mockCollection.find).toHaveBeenCalledWith({ lockID });
+      expect(mockCollection.updateOne).toHaveBeenCalledWith({
+        lockID,
+        writer: "",
+      }, {
+        $addToSet: {
+          readers: clientID,
+        },
+      });
+    });
+
+    it("inserts a lock if none exists", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection._cursor.next = jest.fn()
+        .mockReturnValueOnce(Promise.resolve(null))
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "" }));
+      const lock = new RWMutex(mockCollection, lockID, clientID);
+      await lock.rLock();
+
+      expect(mockCollection.find).toHaveBeenCalledWith({ lockID });
+      expect(mockCollection.insert).toHaveBeenCalledWith({
+        lockID,
+        readers: [],
+        writer: "",
+      });
+      expect(mockCollection.updateOne).toHaveBeenCalledWith({
+        lockID,
+        writer: "",
+      }, {
+        $addToSet: {
+          readers: clientID,
+        },
+      });
+    });
+
+    it("waits if the lock is already in use", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection._cursor.next = jest.fn()
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "different" }));
+      mockCollection.updateOne = jest.fn()
+        .mockReturnValueOnce(Promise.resolve({ matchedCount: 0 }))
+        .mockReturnValueOnce(Promise.resolve({ matchedCount: 1 }));
+      const lock = new RWMutex(mockCollection, lockID, clientID, { sleepTime: 1 });
+      await lock.rLock();
+
+      expect(mockCollection.find).toHaveBeenCalledTimes(1);
+      expect(mockCollection.find).toHaveBeenCalledWith({ lockID });
+      expect(mockCollection.updateOne).toHaveBeenCalledTimes(2);
+      expect(mockCollection.updateOne).toHaveBeenCalledWith({
+        lockID,
+        writer: "",
+      }, {
+        $addToSet: {
+          readers: clientID,
+        },
+      });
+    });
+
+    it("re-enters the lock if the client id already has the lock", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection._cursor.next = jest.fn()
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: ["different", clientID], writer: "" }));
+      const lock = new RWMutex(mockCollection, lockID, clientID, { sleepTime: 1 });
+      await lock.rLock();
+
+      expect(mockCollection.find).toHaveBeenCalledTimes(1);
+      expect(mockCollection.find).toHaveBeenCalledWith({ lockID });
+      expect(mockCollection.insert).toHaveBeenCalledTimes(0);
+      expect(mockCollection.updateOne).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe(".rUnlock()", () => {
+    it("releases the lock", async () => {
+      const mockCollection = new MockCollection();
+      const lock = new RWMutex(mockCollection, lockID, clientID);
+      await lock.rUnlock();
+
+      expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
+      expect(mockCollection.updateOne).toHaveBeenCalledWith({
+        lockID,
+        readers: clientID,
+      }, {
+        $pull: {
+          readers: clientID,
+        },
+      });
+    });
+
+    it("returns an error if the client did not hold the lock", async () => {
+      const mockCollection = new MockCollection();
+      mockCollection.updateOne = jest.fn().mockReturnValue(Promise.resolve({ matchedCount: 0 }));
+      const lock = new RWMutex(mockCollection, lockID, clientID);
+
+      try {
+        await lock.rUnlock();
+      } catch (err) {
+        expect(err.message).toBe("lock not currently held by client: 1");
+        expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
+        expect(mockCollection.updateOne).toHaveBeenCalledWith({
+          lockID,
+          readers: clientID,
+        }, {
+          $pull: {
+            readers: clientID,
+          },
+        });
+        return;
+      }
+      throw new Error("expected unlock to error");
+    });
+  });
+});

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -2,7 +2,7 @@ import * as MongoClient from "mongodb";
 
 import RWMutex from "../lib/RWMutex";
 
-const MONGO_URL = "mongodb://localhost:27017/test";
+const MONGO_URL = "mongodb://127.0.0.1:27017/test";
 const lockID = "lockID";
 const clientID = "1";
 
@@ -12,17 +12,18 @@ describe("RWMutex", () => {
   beforeAll(async () => {
     const db = await MongoClient.connect(MONGO_URL);
     collection = db.collection("lock_test");
-    return await collection.createIndex("lockID", { unique: true });
   });
 
   // Reset the collection before each test
-  beforeEach(async () => await collection.drop());
+  beforeEach(async () => {
+    await collection.drop();
+    await collection.createIndex("lockID", { unique: true });
+  });
 
   describe(".lock()", () => {
     it("inserts a lock if none exists", async () => {
       const lock = new RWMutex(collection, lockID, clientID);
-      const acquired = await lock.lock();
-      expect(acquired).toBe(true);
+      await lock.lock();
 
       const lockObject = await collection.find({ lockID }).limit(1).next();
       expect(lockObject).not.toBeNull();

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -1,0 +1,50 @@
+import * as MongoClient from "mongodb";
+
+import RWMutex from "../lib/RWMutex";
+
+const MONGO_URL = "mongodb://localhost:27017/test";
+const lockID = "lockID";
+const clientID = "1";
+
+describe("RWMutex", () => {
+  // Connect to the database
+  let collection = null;
+  beforeAll(async () => {
+    const db = await MongoClient.connect(MONGO_URL);
+    collection = db.collection("lock_test");
+    return await collection.createIndex("lockID", { unique: true });
+  });
+
+  // Reset the collection before each test
+  beforeEach(async () => await collection.drop());
+
+  describe(".lock()", () => {
+    it("inserts a lock if none exists", async () => {
+      const lock = new RWMutex(collection, lockID, clientID);
+      const acquired = await lock.lock();
+      expect(acquired).toBe(true);
+
+      const lockObject = await collection.find({ lockID }).limit(1).next();
+      expect(lockObject).not.toBeNull();
+      delete lockObject._id;
+      return expect(lockObject).toMatchObject({
+        lastWriter: "",
+        lockID,
+        readers: [],
+        writer: "1",
+      });
+    });
+  });
+
+  describe(".unlock()", () => {
+    it("throws an error if lock is not held", async () => {
+      const lock = new RWMutex(collection, lockID, clientID);
+      try {
+        await lock.unlock();
+      } catch (err) {
+        return expect(err.message).toEqual("lock not currently held by client: 1");
+      }
+      throw new Error("expected error to be thrown");
+    });
+  });
+});

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -6,7 +6,7 @@ const MONGO_URL = "mongodb://127.0.0.1:27017/test";
 const lockID = "lockID";
 const clientID = "1";
 
-describe("RWMutex", () => {
+describe("Integration Test: RWMutex", () => {
   // Connect to the database
   let db; // only used for cleanup
   let collection;
@@ -31,7 +31,6 @@ describe("RWMutex", () => {
       expect(lockObject).not.toBeNull();
       delete lockObject._id;
       return expect(lockObject).toMatchObject({
-        lastWriter: "",
         lockID,
         readers: [],
         writer: "1",

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -8,17 +8,19 @@ const clientID = "1";
 
 describe("RWMutex", () => {
   // Connect to the database
-  let collection = null;
+  let db; // only used for cleanup
+  let collection;
   beforeAll(async () => {
-    const db = await MongoClient.connect(MONGO_URL);
+    db = await MongoClient.connect(MONGO_URL);
     collection = db.collection("lock_test");
-  });
-
-  // Reset the collection before each test
-  beforeEach(async () => {
-    await collection.drop();
     await collection.createIndex("lockID", { unique: true });
   });
+
+  // Must close the connection or jest will hang
+  afterAll(() => db.close());
+
+  // Reset the collection before each test
+  beforeEach(() => collection.deleteMany({}));
 
   describe(".lock()", () => {
     it("inserts a lock if none exists", async () => {

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -44,7 +44,7 @@ describe("Integration Test: RWMutex", () => {
       try {
         await lock.unlock();
       } catch (err) {
-        return expect(err.message).toEqual("lock not currently held by client: 1");
+        return expect(err.message).toEqual("lock lockID not currently held by client: 1");
       }
       throw new Error("expected error to be thrown");
     });

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -179,10 +179,8 @@ export default class RWMutex {
     }
 
     if (!lock) {
-      // lock doesn't exist yet, so we should create it. Empty string is considered
-      // lexographically < any other string, so we can use that as the zero value
+      // lock doesn't exist yet, so we should create it
       lock = {
-        lastWriter: "",
         lockID,
         readers: [],
         writer: "",

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -1,0 +1,162 @@
+function timeoutPromise(delay) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, delay);
+  });
+}
+
+/*
+ * Client representation of a mutex in the database
+ */
+export default class RWMutex {
+  _coll;
+  _lockID;
+  _clientID;
+  _options;
+
+  constructor(coll, lockID, clientID, options = { sleepTime: 5000 }) {
+    this._coll = coll;
+    // TODO: typecheck these
+    this._lockID = lockID;
+    this._clientID = clientID;
+    this._options = options;
+  }
+
+  async lock() {
+    // In a loop, do the following:
+    // 1. Check clientID of the lock. If lock.clientID > this.clientID, bail
+    // 2. Acquire the lock
+    while (true) {
+      // Find the lock
+      let lock;
+      try {
+        // find the lock
+        lock = await this._coll.find({ lockID: this._lockID }).limit(1).next();
+        if (!lock) {
+          // lock doesn't exist yet, so we should create it. Empty string is considered
+          // lexographically < any other string, so we can use that as the zero value
+          await this._coll.insert({
+            lockID: this._lockID,
+            readers: [],
+            writer: "",
+          });
+          continue;
+        }
+      } catch (err) {
+        throw new Error(`error finding lock: ${err.message}`);
+      }
+
+      // if this clientID already has the lock, we re-enter the lock and return
+      if (lock.writer === this._clientID) {
+        return;
+      }
+
+      // Acquire the lock
+      try {
+        const result = await this._coll.updateOne({
+          lockID: this._lockID,
+          readers: [],
+          writer: "",
+        }, {
+          $set: {
+            writer: this._clientID,
+          },
+        });
+        if (result.matchedCount > 0) {
+          return true;
+        }
+      } catch (err) {
+        throw new Error(`error aquiring lock: ${err.message}`);
+      }
+
+      await timeoutPromise(this._options.sleepTime);
+    }
+  }
+
+  async unlock() {
+    let result;
+    try {
+      result = await this._coll.updateOne({
+        lockID: this._lockID,
+        writer: this._clientID,
+      }, {
+        $set: {
+          writer: "",
+        },
+      });
+    } catch (err) {
+      throw new Error(`error releasing lock: ${err.message}`);
+    }
+    if (result.matchedCount === 0) {
+      throw new Error(`lock not currently held by client: ${this._clientID}`);
+    }
+    return;
+  }
+
+  async rLock() {
+    while (true) {
+      let lock;
+      try {
+        // find the lock
+        lock = await this._coll.find({ lockID: this._lockID }).limit(1).next();
+        if (!lock) {
+          // lock doesn't exist yet, so we should create it. Empty string is considered
+          // lexographically < any other string, so we can use that as the zero value
+          await this._coll.insert({
+            lastWriter: "",
+            lockID: this._lockID,
+            readers: [],
+            writer: "",
+          });
+          continue;
+        }
+      } catch (err) {
+        throw new Error(`error finding lock: ${err.message}`);
+      }
+
+      // Acquire the lock
+      try {
+        const result = await this._coll.updateOne({
+          lockID: this._lockID,
+          writer: "",
+        }, {
+          $addToSet: {
+            readers: this._clientID,
+          },
+        });
+        // We check matchedCount rather than modifiedCount here to make the lock re-enterable.
+        // If the lock should not be re-enterable, or clientIDs are not unique, this
+        // implemenation will break.
+        // TODO: allow configurable lock to make it not re-enterable
+        if (result.matchedCount > 0) {
+          return;
+        }
+      } catch (err) {
+        throw new Error(`error aquiring lock: ${err.message}`);
+      }
+
+      await timeoutPromise(this._options.sleepTime);
+    }
+  }
+
+  async rUnlock() {
+    let result;
+    try {
+      result = await this._coll.updateOne({
+        lockID: this._lockID,
+        readers: this._clientID,
+      }, {
+        $pullAll: {
+          readers: [this._clientID],
+        }
+      });
+    } catch (err) {
+      throw new Error(`error releasing lock: ${err.message}`);
+    }
+    if (result.matchedCount === 0) {
+      throw new Error(`lock not currently held by client: ${this._clientID}`);
+    }
+    return;
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,7 @@
-// Export code here
+import RWMutex from "./RWMutex";
+
+// Locks
+export RWMutex;
+
+// Default export (only here to satisfy linter right now)
+export default {};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 import RWMutex from "./RWMutex";
 
 // Locks
-export RWMutex;
+export { RWMutex };
 
 // Default export (only here to satisfy linter right now)
 export default {};

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "TODO",
+  "name": "mongo-lock-node",
   "version": "0.0.1",
-  "description": "{{.Description}}",
+  "description": "a distributed lock client backed by mongo",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "jest"
+    "test": "jest --no-cache"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -32,9 +32,7 @@
     "jest": "^18.1.0",
     "ts-jest": "^18.0.3",
     "tslint": "^3.15.1",
-    "typescript": "^2.1.5"
-  },
-  "dependencies": {
+    "typescript": "^2.1.5",
     "mongodb": "^2.2.24"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
     "ts-jest": "^18.0.3",
     "tslint": "^3.15.1",
     "typescript": "^2.1.5"
+  },
+  "dependencies": {
+    "mongodb": "^2.2.24"
   }
 }


### PR DESCRIPTION
Adds initial implementation of the RWMutex, and 2 tests just for
basic verification (More tests on the way in a subsequent PR).
Currently, this lock is re-enterable (in the future, we should make
this a configurable option).