### PR TITLE
Fix build errors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,18 +1,16 @@
 machine:
+  node:
+    version: 6.2.2
   post:
   - cd $HOME && git clone --depth 1 -v git@github.com:clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
   services:
   - docker
+dependencies:
+  override:
+  - npm install
 compile:
   override:
   - make build
 test:
   override:
   - make test
-deployment:
-  all:
-    branch: master
-    owner: Clever
-    commands:
-    - $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
-    - $HOME/ci-scripts/circleci/catapult-publish $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS $APP_NAME

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,0 +1,1 @@
+// Export code here

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,6 @@
     },
     "exclude": [
         "node_modules"
-    ]
+    ],
+    "files": ["lib/index.ts"]
 }


### PR DESCRIPTION
We're seeing circle.yml build errors for a few reasons:
- Circle.yml default node version fails due to our peer dependency setup.
- TSLint fails with no files to lint passed in argument
- Typescript compile fails with no entry point