### PR TITLE
Ding 1931

### DIFF
--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -1,5 +1,4 @@
 import {
-  Collection as MongoCollection,
   WithId,
   MongoError,
   InsertOneResult,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,9 @@
 import RWMutex from "./RWMutex";
+import { MongoLockCollection, MongoLock } from "./RWMutex";
+
 
 // Locks
-export { RWMutex };
+export { RWMutex, MongoLockCollection, MongoLock};
 
 // Default export (only here to satisfy linter right now)
 export default {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-lock-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "a distributed lock client backed by mongo",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Jira Ticket
https://clever.atlassian.net/browse/DING-1931

## Overview
In order to migrate our autosync workers off of using redis we needed to update our node library used for interacting with the mongo districtlocks collection.  This PR exports more classes so they are usable in package consumers

## Testing
Several new test cases were added to make our integration testing more robust.
## Roll Out