### PR TITLE
fixing build output so we can actually import this module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 # vendored dependencies
 node_modules
 
+dist
+

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+"@clever/prettier-config"

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ lint: format-check lint-es
 
 build:
 	@echo "Building..."
-	@npm run --silent build
+	@rm -rf ./dist/
+	@$(TSC) --declaration
 
 install_deps:
 	npm install

--- a/__mocks__/MockCollection.ts
+++ b/__mocks__/MockCollection.ts
@@ -1,13 +1,9 @@
 export default class MockCollection {
-  findOne;
   deleteOne;
-  insertOne;
   updateOne;
 
   constructor() {
-    this.findOne = jest.fn(() => Promise.resolve(null));
     this.deleteOne = jest.fn(() => Promise.resolve({ deletedCount: 1 }));
-    this.insertOne = jest.fn(() => Promise.resolve({ matchedCount: 1 }));
     this.updateOne = jest.fn(() => Promise.resolve({ matchedCount: 1 }));
   }
 }

--- a/__mocks__/MockCollection.ts
+++ b/__mocks__/MockCollection.ts
@@ -1,10 +1,12 @@
 export default class MockCollection {
   findOne;
+  deleteOne;
   insertOne;
   updateOne;
 
   constructor() {
     this.findOne = jest.fn(() => Promise.resolve(null));
+    this.deleteOne = jest.fn(() => Promise.resolve({ deletedCount: 1 }));
     this.insertOne = jest.fn(() => Promise.resolve({ matchedCount: 1 }));
     this.updateOne = jest.fn(() => Promise.resolve({ matchedCount: 1 }));
   }

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -12,9 +12,7 @@ describe("RWMutex", () => {
       const mockCollection = new MockCollection();
       mockCollection.findOne = jest
         .fn()
-        .mockReturnValueOnce(
-          Promise.resolve({ lockID, readers: [], writer: "" })
-        );
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "" }));
       const lock = new RWMutex(mockCollection, lockID, clientID);
       await lock.lock();
 
@@ -29,7 +27,7 @@ describe("RWMutex", () => {
           $set: {
             writer: "1",
           },
-        }
+        },
       );
     });
 
@@ -38,9 +36,7 @@ describe("RWMutex", () => {
       mockCollection.findOne = jest
         .fn()
         .mockReturnValueOnce(Promise.resolve(null))
-        .mockReturnValueOnce(
-          Promise.resolve({ lockID, readers: [], writer: "" })
-        );
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "" }));
       const lock = new RWMutex(mockCollection, lockID, clientID);
       await lock.lock();
 
@@ -60,7 +56,7 @@ describe("RWMutex", () => {
           $set: {
             writer: "1",
           },
-        }
+        },
       );
     });
 
@@ -68,9 +64,7 @@ describe("RWMutex", () => {
       const mockCollection = new MockCollection();
       mockCollection.findOne = jest
         .fn()
-        .mockReturnValueOnce(
-          Promise.resolve({ lockID, readers: [], writer: "different" })
-        );
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "different" }));
       mockCollection.updateOne = jest
         .fn()
         .mockReturnValueOnce(Promise.resolve({ matchedCount: 0 }))
@@ -93,7 +87,7 @@ describe("RWMutex", () => {
           $set: {
             writer: "1",
           },
-        }
+        },
       );
     });
 
@@ -101,9 +95,7 @@ describe("RWMutex", () => {
       const mockCollection = new MockCollection();
       mockCollection.findOne = jest
         .fn()
-        .mockReturnValueOnce(
-          Promise.resolve({ lockID, readers: [], writer: clientID })
-        );
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: clientID }));
       const lock = new RWMutex(mockCollection, lockID, clientID, {
         sleepTime: 1,
       });
@@ -132,15 +124,13 @@ describe("RWMutex", () => {
           $set: {
             writer: "",
           },
-        }
+        },
       );
     });
 
     it("returns an error if the client did not hold the lock", async () => {
       const mockCollection = new MockCollection();
-      mockCollection.updateOne = jest
-        .fn()
-        .mockReturnValue(Promise.resolve({ matchedCount: 0 }));
+      mockCollection.updateOne = jest.fn().mockReturnValue(Promise.resolve({ matchedCount: 0 }));
       const lock = new RWMutex(mockCollection, lockID, clientID);
 
       try {
@@ -157,7 +147,7 @@ describe("RWMutex", () => {
             $set: {
               writer: "",
             },
-          }
+          },
         );
         return;
       }
@@ -170,9 +160,7 @@ describe("RWMutex", () => {
       const mockCollection = new MockCollection();
       mockCollection.findOne = jest
         .fn()
-        .mockReturnValueOnce(
-          Promise.resolve({ lockID, readers: [], writer: "" })
-        );
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "" }));
       const lock = new RWMutex(mockCollection, lockID, clientID);
       await lock.rLock();
 
@@ -186,7 +174,7 @@ describe("RWMutex", () => {
           $addToSet: {
             readers: clientID,
           },
-        }
+        },
       );
     });
 
@@ -195,9 +183,7 @@ describe("RWMutex", () => {
       mockCollection.findOne = jest
         .fn()
         .mockReturnValueOnce(Promise.resolve(null))
-        .mockReturnValueOnce(
-          Promise.resolve({ lockID, readers: [], writer: "" })
-        );
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "" }));
       const lock = new RWMutex(mockCollection, lockID, clientID);
       await lock.rLock();
 
@@ -216,7 +202,7 @@ describe("RWMutex", () => {
           $addToSet: {
             readers: clientID,
           },
-        }
+        },
       );
     });
 
@@ -224,9 +210,7 @@ describe("RWMutex", () => {
       const mockCollection = new MockCollection();
       mockCollection.findOne = jest
         .fn()
-        .mockReturnValueOnce(
-          Promise.resolve({ lockID, readers: [], writer: "different" })
-        );
+        .mockReturnValueOnce(Promise.resolve({ lockID, readers: [], writer: "different" }));
       mockCollection.updateOne = jest
         .fn()
         .mockReturnValueOnce(Promise.resolve({ matchedCount: 0 }))
@@ -248,7 +232,7 @@ describe("RWMutex", () => {
           $addToSet: {
             readers: clientID,
           },
-        }
+        },
       );
     });
 
@@ -259,7 +243,7 @@ describe("RWMutex", () => {
           lockID,
           readers: ["different", clientID],
           writer: "",
-        })
+        }),
       );
       const lock = new RWMutex(mockCollection, lockID, clientID, {
         sleepTime: 1,
@@ -289,15 +273,13 @@ describe("RWMutex", () => {
           $pull: {
             readers: clientID,
           },
-        }
+        },
       );
     });
 
     it("returns an error if the client did not hold the lock", async () => {
       const mockCollection = new MockCollection();
-      mockCollection.updateOne = jest
-        .fn()
-        .mockReturnValue(Promise.resolve({ matchedCount: 0 }));
+      mockCollection.updateOne = jest.fn().mockReturnValue(Promise.resolve({ matchedCount: 0 }));
       const lock = new RWMutex(mockCollection, lockID, clientID);
 
       try {
@@ -314,7 +296,7 @@ describe("RWMutex", () => {
             $pull: {
               readers: clientID,
             },
-          }
+          },
         );
         return;
       }

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -1,4 +1,4 @@
-import RWMutex from "../lib/RWMutex";
+import RWMutex, { emptyReadersQuery } from "../lib/RWMutex";
 import MockCollection from "../__mocks__/MockCollection";
 import { MongoError } from "mongodb";
 
@@ -16,20 +16,25 @@ describe("RWMutex", () => {
 
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
-          lockID,
-          readers: [],
-          $or: [
+          lockID: lockID,
+          $and: [
+            emptyReadersQuery,
             {
-              writer: "",
-            },
-            {
-              writer: clientID,
+              $or: [
+                {
+                  writer: "",
+                },
+                {
+                  writer: clientID,
+                },
+              ],
             },
           ],
         },
         {
           $set: {
             writer: clientID,
+            readers: [],
           },
         },
         { upsert: true },
@@ -48,20 +53,25 @@ describe("RWMutex", () => {
 
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
-          lockID,
-          readers: [],
-          $or: [
+          lockID: lockID,
+          $and: [
+            emptyReadersQuery,
             {
-              writer: "",
-            },
-            {
-              writer: clientID,
+              $or: [
+                {
+                  writer: "",
+                },
+                {
+                  writer: clientID,
+                },
+              ],
             },
           ],
         },
         {
           $set: {
             writer: clientID,
+            readers: [],
           },
         },
         { upsert: true },
@@ -83,20 +93,25 @@ describe("RWMutex", () => {
       expect(mockCollection.updateOne).toHaveBeenCalledTimes(2);
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
-          lockID,
-          readers: [],
-          $or: [
+          lockID: lockID,
+          $and: [
+            emptyReadersQuery,
             {
-              writer: "",
-            },
-            {
-              writer: clientID,
+              $or: [
+                {
+                  writer: "",
+                },
+                {
+                  writer: clientID,
+                },
+              ],
             },
           ],
         },
         {
           $set: {
             writer: clientID,
+            readers: [],
           },
         },
         { upsert: true },
@@ -116,20 +131,25 @@ describe("RWMutex", () => {
       expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
-          lockID,
-          readers: [],
-          $or: [
+          lockID: lockID,
+          $and: [
+            emptyReadersQuery,
             {
-              writer: "",
-            },
-            {
-              writer: clientID,
+              $or: [
+                {
+                  writer: "",
+                },
+                {
+                  writer: clientID,
+                },
+              ],
             },
           ],
         },
         {
           $set: {
             writer: clientID,
+            readers: [],
           },
         },
         { upsert: true },

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -173,9 +173,12 @@ describe("RWMutex", () => {
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
           lockID,
-          writer: "",
+          $or: emptyWriterQuery["$or"],
         },
         {
+          $set: {
+            writer: "",
+          },
           $addToSet: {
             readers: clientID,
           },
@@ -192,9 +195,12 @@ describe("RWMutex", () => {
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
           lockID,
-          writer: "",
+          $or: emptyWriterQuery["$or"],
         },
         {
+          $set: {
+            writer: "",
+          },
           $addToSet: {
             readers: clientID,
           },
@@ -219,9 +225,12 @@ describe("RWMutex", () => {
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
           lockID,
-          writer: "",
+          $or: emptyWriterQuery["$or"],
         },
         {
+          $set: {
+            writer: "",
+          },
           $addToSet: {
             readers: clientID,
           },
@@ -244,9 +253,12 @@ describe("RWMutex", () => {
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
           lockID,
-          writer: "",
+          $or: emptyWriterQuery["$or"],
         },
         {
+          $set: {
+            writer: "",
+          },
           $addToSet: {
             readers: clientID,
           },

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -22,6 +22,9 @@ describe("RWMutex", () => {
             {
               $or: [
                 {
+                  writer: { $exists: false },
+                },
+                {
                   writer: "",
                 },
                 {
@@ -58,6 +61,9 @@ describe("RWMutex", () => {
             emptyReadersQuery,
             {
               $or: [
+                {
+                  writer: { $exists: false },
+                },
                 {
                   writer: "",
                 },
@@ -99,6 +105,9 @@ describe("RWMutex", () => {
             {
               $or: [
                 {
+                  writer: { $exists: false },
+                },
+                {
                   writer: "",
                 },
                 {
@@ -136,6 +145,9 @@ describe("RWMutex", () => {
             emptyReadersQuery,
             {
               $or: [
+                {
+                  writer: { $exists: false },
+                },
                 {
                   writer: "",
                 },

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -1,4 +1,4 @@
-import RWMutex, { emptyReadersQuery } from "../lib/RWMutex";
+import RWMutex, { emptyReadersQuery, emptyWriterQuery } from "../lib/RWMutex";
 import MockCollection from "../__mocks__/MockCollection";
 import { MongoError } from "mongodb";
 
@@ -13,26 +13,12 @@ describe("RWMutex", () => {
       const mockCollection = new MockCollection();
       const lock = new RWMutex(mockCollection, lockID, clientID);
       await lock.lock();
-
+      const writerQuery = JSON.parse(JSON.stringify(emptyWriterQuery));
+      writerQuery["$or"].push({ writer: clientID });
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
           lockID: lockID,
-          $and: [
-            emptyReadersQuery,
-            {
-              $or: [
-                {
-                  writer: { $exists: false },
-                },
-                {
-                  writer: "",
-                },
-                {
-                  writer: clientID,
-                },
-              ],
-            },
-          ],
+          $and: [emptyReadersQuery, writerQuery],
         },
         {
           $set: {
@@ -53,26 +39,12 @@ describe("RWMutex", () => {
         }),
       );
       await lock.lock();
-
+      const writerQuery = JSON.parse(JSON.stringify(emptyWriterQuery));
+      writerQuery["$or"].push({ writer: clientID });
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
           lockID: lockID,
-          $and: [
-            emptyReadersQuery,
-            {
-              $or: [
-                {
-                  writer: { $exists: false },
-                },
-                {
-                  writer: "",
-                },
-                {
-                  writer: clientID,
-                },
-              ],
-            },
-          ],
+          $and: [emptyReadersQuery, writerQuery],
         },
         {
           $set: {
@@ -96,26 +68,13 @@ describe("RWMutex", () => {
         sleepTime: 1,
       });
       await lock.lock();
+      const writerQuery = JSON.parse(JSON.stringify(emptyWriterQuery));
+      writerQuery["$or"].push({ writer: clientID });
       expect(mockCollection.updateOne).toHaveBeenCalledTimes(2);
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
           lockID: lockID,
-          $and: [
-            emptyReadersQuery,
-            {
-              $or: [
-                {
-                  writer: { $exists: false },
-                },
-                {
-                  writer: "",
-                },
-                {
-                  writer: clientID,
-                },
-              ],
-            },
-          ],
+          $and: [emptyReadersQuery, writerQuery],
         },
         {
           $set: {
@@ -136,27 +95,13 @@ describe("RWMutex", () => {
         .fn()
         .mockReturnValueOnce(Promise.resolve({ matchedCount: 1 }));
       await lock.lock();
-
+      const writerQuery = JSON.parse(JSON.stringify(emptyWriterQuery));
+      writerQuery["$or"].push({ writer: clientID });
       expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
       expect(mockCollection.updateOne).toHaveBeenCalledWith(
         {
           lockID: lockID,
-          $and: [
-            emptyReadersQuery,
-            {
-              $or: [
-                {
-                  writer: { $exists: false },
-                },
-                {
-                  writer: "",
-                },
-                {
-                  writer: clientID,
-                },
-              ],
-            },
-          ],
+          $and: [emptyReadersQuery, writerQuery],
         },
         {
           $set: {

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -124,7 +124,7 @@ describe("RWMutex", () => {
       expect(mockCollection.deleteOne).toHaveBeenCalledWith({
         lockID,
         writer: clientID,
-        readers: [],
+        $or: emptyReadersQuery["$or"],
       });
     });
 
@@ -144,7 +144,7 @@ describe("RWMutex", () => {
         expect(mockCollection.deleteOne).toHaveBeenCalledWith({
           lockID,
           writer: clientID,
-          readers: [],
+          $or: emptyReadersQuery["$or"],
         });
         expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
         expect(mockCollection.updateOne).toHaveBeenCalledWith(

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -277,7 +277,7 @@ describe("RWMutex", () => {
       expect(mockCollection.deleteOne).toHaveBeenCalledTimes(1);
       expect(mockCollection.deleteOne).toHaveBeenCalledWith({
         lockID,
-        writer: "",
+        $or: emptyWriterQuery["$or"],
         readers: { $size: 1, $all: [clientID] },
       });
     });
@@ -291,7 +291,7 @@ describe("RWMutex", () => {
       expect(mockCollection.deleteOne).toHaveBeenCalledTimes(1);
       expect(mockCollection.deleteOne).toHaveBeenCalledWith({
         lockID,
-        writer: "",
+        $or: emptyWriterQuery["$or"],
         readers: { $size: 1, $all: [clientID] },
       });
       expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);
@@ -321,7 +321,7 @@ describe("RWMutex", () => {
         expect(mockCollection.deleteOne).toHaveBeenCalledTimes(1);
         expect(mockCollection.deleteOne).toHaveBeenCalledWith({
           lockID,
-          writer: "",
+          $or: emptyWriterQuery["$or"],
           readers: { $size: 1, $all: [clientID] },
         });
         expect(mockCollection.updateOne).toHaveBeenCalledTimes(1);

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -72,9 +72,7 @@ describe("Integration Test: RWMutex", () => {
       try {
         await lock.unlock();
       } catch (err) {
-        return expect(err.message).toEqual(
-          "lock lockID not currently held by client: 1"
-        );
+        return expect(err.message).toEqual("lock lockID not currently held by client: 1");
       }
       throw new Error("expected error to be thrown");
     });
@@ -135,7 +133,6 @@ describe("Integration Test: RWMutex", () => {
         writer: "2",
       });
     });
-
 
     it("waits for the lock to be released if a reader has it", async () => {
       const lock = new RWMutex(collection, lockID, clientID);
@@ -236,7 +233,6 @@ describe("Integration Test: RWMutex", () => {
         writer: "",
       });
 
-
       await lock.rUnlock();
 
       lockObject = await collection.findOne({ lockID });
@@ -254,13 +250,10 @@ describe("Integration Test: RWMutex", () => {
       try {
         await lock.rUnlock();
       } catch (err) {
-        return expect(err.message).toEqual(
-          "lock lockID not currently held by client: 1"
-        );
+        return expect(err.message).toEqual("lock lockID not currently held by client: 1");
       }
       throw new Error("expected error to be thrown");
     });
-
 
     it("waits for the lock to be released if a writer has it", async () => {
       const lock = new RWMutex(collection, lockID, clientID);

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -54,7 +54,7 @@ describe("Integration Test: RWMutex", () => {
 
   describe(".lock()", () => {
     it("inserts a lock if none exists", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.lock();
 
       const lockObject = await collection.findOne({ lockID });
@@ -68,7 +68,7 @@ describe("Integration Test: RWMutex", () => {
     });
 
     it(".unlock() throws an error if lock is not held", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       try {
         await lock.unlock();
       } catch (err) {
@@ -78,7 +78,7 @@ describe("Integration Test: RWMutex", () => {
     });
 
     it("releases the lock correctly", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.lock();
 
       let lockObject = await collection.findOne({ lockID });
@@ -103,7 +103,7 @@ describe("Integration Test: RWMutex", () => {
     });
 
     it("waits for the lock to be released if a writer has it", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.lock();
 
       let lockObject = await collection.findOne({ lockID });
@@ -135,7 +135,7 @@ describe("Integration Test: RWMutex", () => {
     });
 
     it("waits for the lock to be released if a reader has it", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.rLock();
 
       let lockObject = await collection.findOne({ lockID });
@@ -169,7 +169,7 @@ describe("Integration Test: RWMutex", () => {
 
   describe(".rLock()", () => {
     it("acquires the lock", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.rLock();
 
       const lockObject = await collection.findOne({ lockID });
@@ -183,7 +183,7 @@ describe("Integration Test: RWMutex", () => {
     });
 
     it("acquires the lock even if a reader already has it", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.rLock();
 
       let lockObject = await collection.findOne({ lockID });
@@ -195,7 +195,7 @@ describe("Integration Test: RWMutex", () => {
         writer: "",
       });
 
-      const lock2 = new RWMutex(collection, lockID, "2");
+      const lock2 = new RWMutex(collection, lockID, "2", { sleepTime: 100 });
       await lock2.rLock();
 
       lockObject = await collection.findOne({ lockID });
@@ -209,7 +209,7 @@ describe("Integration Test: RWMutex", () => {
     });
 
     it("releases the lock correctly", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.rLock();
 
       let lockObject = await collection.findOne({ lockID });
@@ -221,7 +221,7 @@ describe("Integration Test: RWMutex", () => {
         writer: "",
       });
 
-      const lock2 = new RWMutex(collection, lockID, "2");
+      const lock2 = new RWMutex(collection, lockID, "2", { sleepTime: 100 });
       await lock2.rLock();
 
       lockObject = await collection.findOne({ lockID });
@@ -246,7 +246,7 @@ describe("Integration Test: RWMutex", () => {
     });
 
     it(".rUnlock() throws an error if lock is not held", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       try {
         await lock.rUnlock();
       } catch (err) {
@@ -256,7 +256,7 @@ describe("Integration Test: RWMutex", () => {
     });
 
     it("waits for the lock to be released if a writer has it", async () => {
-      const lock = new RWMutex(collection, lockID, clientID);
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.lock();
 
       let lockObject = await collection.findOne({ lockID });

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -93,13 +93,7 @@ describe("Integration Test: RWMutex", () => {
       await lock.unlock();
 
       lockObject = await collection.findOne({ lockID });
-      expect(lockObject).not.toBeNull();
-      delete lockObject._id;
-      return expect(lockObject).toMatchObject({
-        lockID,
-        readers: [],
-        writer: "",
-      });
+      return expect(lockObject).toBeNull();
     });
 
     it("waits for the lock to be released if a writer has it", async () => {
@@ -238,11 +232,15 @@ describe("Integration Test: RWMutex", () => {
       lockObject = await collection.findOne({ lockID });
       expect(lockObject).not.toBeNull();
       delete lockObject._id;
-      return expect(lockObject).toMatchObject({
+      expect(lockObject).toMatchObject({
         lockID,
         readers: ["2"],
         writer: "",
       });
+
+      await lock2.rUnlock();
+      lockObject = await collection.findOne({ lockID });
+      return expect(lockObject).toBeNull();
     });
 
     it(".rUnlock() throws an error if lock is not held", async () => {
@@ -258,7 +256,6 @@ describe("Integration Test: RWMutex", () => {
     it("waits for the lock to be released if a writer has it", async () => {
       const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.lock();
-
       let lockObject = await collection.findOne({ lockID });
       expect(lockObject).not.toBeNull();
       delete lockObject._id;

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -98,25 +98,12 @@ export default class RWMutex {
         // this will do nothing
         // If a lock exists with this lockID with a different clientID as the writer or readers,
         // this will throw an error which will be caught.  We will then retry.
+        const writerQuery = JSON.parse(JSON.stringify(emptyWriterQuery));
+        writerQuery["$or"].push({ writer: this._clientID });
         const result = await this._coll.updateOne(
           {
             lockID: this._lockID,
-            $and: [
-              emptyReadersQuery,
-              {
-                $or: [
-                  {
-                    writer: { $exists: false },
-                  },
-                  {
-                    writer: "",
-                  },
-                  {
-                    writer: this._clientID,
-                  },
-                ],
-              },
-            ],
+            $and: [emptyReadersQuery, writerQuery],
           },
           {
             $set: {

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -1,9 +1,4 @@
-import {
-  WithId,
-  MongoError,
-  InsertOneResult,
-  UpdateResult,
-} from "mongodb";
+import { WithId, MongoError, InsertOneResult, UpdateResult } from "mongodb";
 
 // Helper function that converts setTimeout to a Promise
 function timeoutPromise(delay) {
@@ -51,7 +46,7 @@ export default class RWMutex {
     coll: MongoLockCollection,
     lockID: string,
     clientID: string,
-    options = { sleepTime: 5000 }
+    options = { sleepTime: 5000 },
   ) {
     this._coll = coll;
     this._lockID = lockID;
@@ -88,7 +83,7 @@ export default class RWMutex {
             $set: {
               writer: this._clientID,
             },
-          }
+          },
         );
         if (result.matchedCount > 0) {
           acquired = true;
@@ -118,15 +113,13 @@ export default class RWMutex {
           $set: {
             writer: "",
           },
-        }
+        },
       );
     } catch (err) {
       throw new Error(`error releasing lock ${this._lockID}: ${err.message}`);
     }
     if (result.matchedCount === 0) {
-      throw new Error(
-        `lock ${this._lockID} not currently held by client: ${this._clientID}`
-      );
+      throw new Error(`lock ${this._lockID} not currently held by client: ${this._clientID}`);
     }
     return;
   }
@@ -159,7 +152,7 @@ export default class RWMutex {
             $addToSet: {
               readers: this._clientID,
             },
-          }
+          },
         );
         // We check matchedCount rather than modifiedCount here to make the lock re-enterable.
         // If the lock should not be re-enterable, or clientIDs are not unique, this
@@ -193,15 +186,13 @@ export default class RWMutex {
           $pull: {
             readers: this._clientID,
           },
-        }
+        },
       );
     } catch (err) {
       throw new Error(`error releasing lock ${this._lockID}: ${err.message}`);
     }
     if (result.matchedCount === 0) {
-      throw new Error(
-        `lock ${this._lockID} not currently held by client: ${this._clientID}`
-      );
+      throw new Error(`lock ${this._lockID} not currently held by client: ${this._clientID}`);
     }
     return;
   }

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -1,11 +1,4 @@
-import {
-  WithId,
-  MongoError,
-  InsertOneResult,
-  UpdateResult,
-  DeleteResult,
-  UpdateOptions,
-} from "mongodb";
+import { MongoError, UpdateResult, DeleteResult, UpdateOptions } from "mongodb";
 
 // Helper function that converts setTimeout to a Promise
 function timeoutPromise(delay) {
@@ -21,9 +14,7 @@ export interface MongoLock {
 }
 
 export interface MongoLockCollection {
-  findOne: (filter: any) => Promise<WithId<MongoLock>>;
   deleteOne: (filter: any) => Promise<DeleteResult>;
-  insertOne: (doc: MongoLock) => Promise<InsertOneResult<MongoLock>>;
   updateOne: (filter: any, update: any, opts?: UpdateOptions) => Promise<UpdateResult<MongoLock>>;
 }
 

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -138,7 +138,7 @@ export default class RWMutex {
       const deleteResult = await this._coll.deleteOne({
         lockID: this._lockID,
         writer: this._clientID,
-        readers: [],
+        $or: emptyReadersQuery["$or"],
       });
       if (deleteResult.deletedCount > 0) {
         return;

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -46,6 +46,8 @@ export const emptyWriterQuery = {
   ],
 };
 
+export const DuplicateKeyErrorCode = 11000;
+
 /*
  * RWMutex implements a distributed reader/writer lock backed by mongodb. Right now it is limited
  * in a few key ways:
@@ -118,7 +120,7 @@ export default class RWMutex {
           return;
         }
       } catch (err) {
-        if (!(err instanceof MongoError) || err.code !== 11000) {
+        if (!(err instanceof MongoError) || err.code !== DuplicateKeyErrorCode) {
           throw new Error(`error aquiring lock ${this._lockID}: ${err.message}`);
         }
       }
@@ -202,7 +204,7 @@ export default class RWMutex {
           return;
         }
       } catch (err) {
-        if (!(err instanceof MongoError) || err.code !== 11000) {
+        if (!(err instanceof MongoError) || err.code !== DuplicateKeyErrorCode) {
           throw new Error(`error aquiring lock ${this._lockID}: ${err.message}`);
         }
       }

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -185,9 +185,12 @@ export default class RWMutex {
         const result = await this._coll.updateOne(
           {
             lockID: this._lockID,
-            writer: "",
+            $or: emptyWriterQuery["$or"],
           },
           {
+            $set: {
+              writer: "",
+            },
             $addToSet: {
               readers: this._clientID,
             },

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -221,7 +221,7 @@ export default class RWMutex {
       // delete lock if this is the only holder
       const deleteResult = await this._coll.deleteOne({
         lockID: this._lockID,
-        writer: "",
+        $or: emptyWriterQuery["$or"],
         readers: { $size: 1, $all: [this._clientID] },
       });
       if (deleteResult.deletedCount > 0) {

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -26,6 +26,23 @@ export const emptyReadersQuery = {
     {
       readers: { $exists: false },
     },
+    {
+      readers: null,
+    },
+  ],
+};
+
+export const emptyWriterQuery = {
+  $or: [
+    {
+      writer: { $exists: false },
+    },
+    {
+      writer: "",
+    },
+    {
+      writer: null,
+    },
   ],
 };
 
@@ -88,6 +105,9 @@ export default class RWMutex {
               emptyReadersQuery,
               {
                 $or: [
+                  {
+                    writer: { $exists: false },
+                  },
                   {
                     writer: "",
                   },

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,9 +1,1 @@
-import RWMutex from "./RWMutex";
-import { MongoLockCollection, MongoLock } from "./RWMutex";
-
-
-// Locks
-export { RWMutex, MongoLockCollection, MongoLock};
-
-// Default export (only here to satisfy linter right now)
-export default {};
+export * from "./RWMutex"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,1 @@
-export * from "./RWMutex"
+export * from "./RWMutex";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo-lock-node",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo-lock-node",
-      "version": "0.1.2",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ts-node": "^10.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo-lock-node",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo-lock-node",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "ts-node": "^10.9.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "testRegex": "/__tests__/.+\\.ts$",
     "transform": {
       "^.+\\.ts$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
-    }
+    },
+    "modulePathIgnorePatterns": ["<rootDir>/dist/"]
   },
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-lock-node",
-  "version": "0.1.2",
+  "version": "1.0.0",
   "description": "a distributed lock client backed by mongo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "mongo-lock-node",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "a distributed lock client backed by mongo",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "jest --no-cache"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "baseUrl": ".",
     "paths": {
       "src/*": ["./lib/*", "./__mocks__/*", "./__tests__/*"]
-    }
+    },
+    "outDir": "dist"
   },
   "exclude": ["jest", "node_modules"]
 }


### PR DESCRIPTION
## Jira Ticket
https://clever.atlassian.net/browse/DING-1931

## Overview
In order to migrate our autosync workers off of using redis we needed to update our node library used for interacting with the mongo districtlocks collection.  This PR does a number of updates:

1. Fixes the build output as before we were not able to import the module correctly
2. Updates the formatting to be in agreement with other Clever repos
3. Causes unlock and rUnlock methods to delete the lock if the lock has no holders besides this client.
4. In order to support deletion of locks we have removed the find or create logic before and replaced it with atomic update and deletion operations. In the lock method

## Testing
Several new test cases were added to make our integration testing more robust.
## Roll Out