### PR TITLE
Ding 1991

### DIFF
--- a/__mocks__/MockCollection.ts
+++ b/__mocks__/MockCollection.ts
@@ -1,8 +1,10 @@
 export default class MockCollection {
+  findOne;
   deleteOne;
   updateOne;
 
   constructor() {
+    this.findOne = jest.fn(() => Promise.resolve());
     this.deleteOne = jest.fn(() => Promise.resolve({ deletedCount: 1 }));
     this.updateOne = jest.fn(() => Promise.resolve({ matchedCount: 1 }));
   }

--- a/__tests__/RWMutex.test.ts
+++ b/__tests__/RWMutex.test.ts
@@ -363,6 +363,9 @@ describe(".overrideLockWriter()", () => {
         $set: {
           writer: clientID,
         },
+        $setOnInsert: {
+          readers: [],
+        },
       },
       { upsert: false },
     );
@@ -381,6 +384,9 @@ describe(".overrideLockWriter()", () => {
       {
         $set: {
           writer: clientID,
+        },
+        $setOnInsert: {
+          readers: [],
         },
       },
       { upsert: true },
@@ -403,6 +409,9 @@ describe(".overrideLockWriter()", () => {
         $set: {
           writer: clientID,
         },
+        $setOnInsert: {
+          readers: [],
+        },
       },
       { upsert: false },
     );
@@ -423,6 +432,9 @@ describe(".overrideLockWriter()", () => {
       {
         $set: {
           writer: clientID,
+        },
+        $setOnInsert: {
+          readers: [],
         },
       },
       { upsert: true },
@@ -448,6 +460,9 @@ describe(".conditionalOverrideLockWriter()", () => {
       {
         $set: {
           writer: clientID,
+        },
+        $setOnInsert: {
+          readers: [],
         },
       },
       { upsert: false },
@@ -489,6 +504,9 @@ describe(".conditionalOverrideLockWriter()", () => {
         $set: {
           writer: clientID,
         },
+        $setOnInsert: {
+          readers: [],
+        },
       },
       { upsert: true },
     );
@@ -527,6 +545,9 @@ describe(".conditionalOverrideLockWriter()", () => {
       {
         $set: {
           writer: clientID,
+        },
+        $setOnInsert: {
+          readers: [],
         },
       },
       { upsert: true },

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -193,6 +193,9 @@ export default class RWMutex {
           $set: {
             writer: this._clientID,
           },
+          $setOnInsert: {
+            readers: [],
+          },
         },
         { upsert: upsert },
       );

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -14,6 +14,7 @@ export interface MongoLock {
 }
 
 export interface MongoLockCollection {
+  findOne: (filter: any) => Promise<MongoLock | null>;
   deleteOne: (filter: any) => Promise<DeleteResult>;
   updateOne: (filter: any, update: any, opts?: UpdateOptions) => Promise<UpdateResult<MongoLock>>;
 }
@@ -87,7 +88,7 @@ export default class RWMutex {
    * Acquires the write lock.
    * @return {Promise} - Promise that resolves when the lock is acquired, rejects if an error occurs
    */
-  async lock() {
+  async lock(): Promise<void> {
     // Loop and do the following:
     // 1. attempt to acquire the lock (must have no readers and no writer)
     // 2. if not acquired, sleep and retry
@@ -137,7 +138,7 @@ export default class RWMutex {
    * Unlocks the write lock. Must have the same lock type
    * @return {Promise} - Resolves when lock is released, rejects if an error occurs
    */
-  async unlock() {
+  async unlock(): Promise<void> {
     let result;
     try {
       // delete lock if this is the only holder
@@ -175,11 +176,76 @@ export default class RWMutex {
     return;
   }
 
+  /**
+   * overrideLockWriter is a method that will override the current writer of the lock with the
+   * clientID of the current instance of the RWMutex.
+   * @param upsert determines whether or not to create a new lock if one does not exist
+   * @returns void
+   */
+  async overrideLockWriter(upsert = false): Promise<void> {
+    let errMsg = `error overriding lock ${this._lockID}`;
+    try { 
+      const result = await this._coll.updateOne(
+        {
+          lockID: this._lockID,
+        },
+        {
+          $set: {
+            writer: this._clientID,
+          },
+        },
+        { upsert: upsert },
+      );
+      if (result.matchedCount > 0 || result.upsertedCount > 0) {
+        return;
+      }
+    } catch (err: unknown) {
+      
+      if (err instanceof Error) {
+        errMsg += `: ${err.message}`;
+      }
+      throw new Error(errMsg);
+    }
+    if (!upsert) {
+      errMsg += ": lock not found";
+      throw new Error(errMsg);
+    }
+    errMsg += ": lock not found, upsert failed";
+    throw new Error(errMsg);
+  }
+
+  /**
+   * conditionalOverrideLockWriter is a method that will override the current writer of the lock with the 
+   * clientID of the current instance of the RWMutex if the conditional function returns true.
+   * @param conditional returns a boolean value based on some comparison of the current lockID in the database and
+   * the lockID of the current instance of the RWMutex
+   * @param upsert determines whether or not to create a new lock if one does not exist
+   * @returns boolean value based on whether or not we overrode the lock
+   */
+  async conditionalOverrideLockWriter(
+    conditional: (oldWriter: string, newWriter: string) => Promise<boolean>,
+    upsert = false): Promise<boolean> { 
+    const mongoLock = await this._coll.findOne({ lockID: this._lockID })
+    if (!mongoLock) {
+      if (!upsert) {
+        return false;
+      }
+      await this.overrideLockWriter(upsert);
+      return true;
+    }
+    const conditionalResult = await conditional(mongoLock.writer, this._clientID);
+    if (conditionalResult) {
+      await this.overrideLockWriter(upsert);
+      return true;
+    }
+    return false;
+}
+
   /*
    * Acquires the read lock.
    * @return {Promise} - Resolves when the lock is acquired, rejects if an error occurs
    */
-  async rLock() {
+  async rLock(): Promise<void> {
     // Loop and do the following:
     // 1. attempt to acquire the lock (must have no writer)
     // 2. if not acquired, sleep and retry
@@ -229,7 +295,7 @@ export default class RWMutex {
    * Unlocks the read lock. Must have the same lock type
    * @return {Promise} - Resolves when lock is released, rejects if an error occurs
    */
-  async rUnlock() {
+  async rUnlock(): Promise<void> {
     let result;
     try {
       // delete lock if this is the only holder

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo-lock-node",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo-lock-node",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ts-node": "^10.9.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo-lock-node",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo-lock-node",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "ts-node": "^10.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-lock-node",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "a distributed lock client backed by mongo",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/DING-1991
**Overview:**
We need to replace the use of redis-reservation in clever-sftp-watcher. This use case is slightly different than others. Instead of simply acquiring locks when they are available we check a value in the lock and see if the current value is more recent.  If so we replace the existing lock value with the new value.  we can mimic this behavior using the writer value set in mongoDB
https://github.com/Clever/clever-sftp-watcher/blob/cbcc895e4b196d469446ce89fd5dbe6f927bb3d6/main.ts#L368
**Testing:**
Added more to our unit test suite and integration test suite
**Roll Out:**