### PR TITLE
Ding 1991

### DIFF
--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -419,9 +419,12 @@ describe("Integration Test: RWMutex", () => {
   });
 
   describe(".conditonalOverrideLockWriter()", () => {
-    const conditional = async (oldWriter: string, newWriter: string): Promise<boolean> => {
-      return oldWriter < newWriter;
-    };
+    let conditional: (oldWriter: string, newWriter: string) => Promise<boolean>;
+    beforeEach(() => { 
+      conditional = async (oldWriter: string, newWriter: string): Promise<boolean> => {
+        return oldWriter < newWriter;
+      };
+    });
 
     it("overrides the lock if the condition is met", async () => {
       const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
@@ -474,6 +477,81 @@ describe("Integration Test: RWMutex", () => {
         writer: "1",
       });
     });
+
+    it("reattempts to override the lock if the writer changed", async () => {
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
+      await lock.lock();
+      let lockObject = await collection.findOne({ lockID });
+      expect(lockObject).not.toBeNull();
+      delete lockObject._id;
+      expect(lockObject).toMatchObject({
+        lockID,
+        readers: [],
+        writer: "1",
+      });
+
+      // to simulate a race condition where the writer changes we will sleep for 3 seconds
+      // before returning the result of the conditional
+      conditional = async (oldWriter: string, newWriter: string): Promise<boolean> => {
+        const successful = oldWriter < newWriter;
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return successful;
+      }
+
+      const lock2 = new RWMutex(collection, lockID, "3", { sleepTime: 100 });
+      const conditionalOverridePromise = lock2.conditionalOverrideLockWriter(conditional);
+      await collection.updateOne({ lockID }, { $set: { writer: "2" } });
+      const success = await conditionalOverridePromise;
+      expect(success).toBe(true);
+
+      lockObject = await collection.findOne({ lockID });
+      expect(lockObject).not.toBeNull();
+      delete lockObject._id;
+      expect(lockObject).toMatchObject({
+        lockID,
+        readers: [],
+        writer: "3",
+      });
+    }, 10000);
+
+
+    it("reattempts to override the lock if the writer changed and fails if the condition is no longer true", async () => {
+      const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
+      await lock.lock();
+      let lockObject = await collection.findOne({ lockID });
+      expect(lockObject).not.toBeNull();
+      delete lockObject._id;
+      expect(lockObject).toMatchObject({
+        lockID,
+        readers: [],
+        writer: "1",
+      });
+
+      // to simulate a race condition where the writer changes we will sleep for 3 seconds
+      // before returning the result of the conditional
+      conditional = async (oldWriter: string, newWriter: string): Promise<boolean> => {
+        const successful = oldWriter < newWriter;
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+        return successful;
+      }
+
+      const lock2 = new RWMutex(collection, lockID, "2", { sleepTime: 100 });
+      const conditionalOverridePromise = lock2.conditionalOverrideLockWriter(conditional);
+      await collection.updateOne({ lockID }, { $set: { writer: "3" } });
+      const success = await conditionalOverridePromise;
+      expect(success).toBe(false);
+
+      lockObject = await collection.findOne({ lockID });
+      expect(lockObject).not.toBeNull();
+      delete lockObject._id;
+      expect(lockObject).toMatchObject({
+        lockID,
+        readers: [],
+        writer: "3",
+      });
+    }, 10000);
+
+
 
     it("upserts the lock if it doesn't exist", async () => {
       const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });

--- a/__tests__/integration.ts
+++ b/__tests__/integration.ts
@@ -339,7 +339,7 @@ describe("Integration Test: RWMutex", () => {
     });
   });
 
-  describe(".overrideLockWriter()", () => {
+  describe(".tryOverrideLockWriter()", () => {
     it("overrides the lock if a writer has it", async () => {
       const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       await lock.lock();
@@ -353,7 +353,7 @@ describe("Integration Test: RWMutex", () => {
       });
 
       const lock2 = new RWMutex(collection, lockID, "2", { sleepTime: 100 });
-      await lock2.overrideLockWriter();
+      await lock2.tryOverrideLockWriter(clientID);
 
       lockObject = await collection.findOne({ lockID });
       expect(lockObject).not.toBeNull();
@@ -367,7 +367,7 @@ describe("Integration Test: RWMutex", () => {
 
     it("upserts the lock if it doesn't exist", async () => {
       const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
-      await lock.overrideLockWriter(true);
+      await lock.tryOverrideLockWriter(clientID, true);
 
       const lockObject = await collection.findOne({ lockID });
       expect(lockObject).not.toBeNull();
@@ -392,7 +392,7 @@ describe("Integration Test: RWMutex", () => {
       });
 
       const lock2 = new RWMutex(collection, lockID, "2", { sleepTime: 100 });
-      await lock2.overrideLockWriter();
+      await lock2.tryOverrideLockWriter("");
 
       lockObject = await collection.findOne({ lockID });
       expect(lockObject).not.toBeNull();
@@ -407,7 +407,7 @@ describe("Integration Test: RWMutex", () => {
     it("throws an error if there is no lock to override and upsert is false", async () => {
       const lock = new RWMutex(collection, lockID, clientID, { sleepTime: 100 });
       try {
-        await lock.overrideLockWriter(false);
+        await lock.tryOverrideLockWriter("", false);
       } catch (err) {
         expect(err).toBeInstanceOf(Error);
         if (err instanceof Error) {

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -176,18 +176,22 @@ export default class RWMutex {
     return;
   }
 
+  overrideWriterSwitchedError = "lock already held by another writer";
   /**
    * overrideLockWriter is a method that will override the current writer of the lock with the
    * clientID of the current instance of the RWMutex.
    * @param upsert determines whether or not to create a new lock if one does not exist
    * @returns void
    */
-  async overrideLockWriter(upsert = false): Promise<void> {
+  async tryOverrideLockWriter(oldWriter: string, upsert = false): Promise<void> {
     let errMsg = `error overriding lock ${this._lockID}`;
+    const writerQuery = JSON.parse(JSON.stringify(emptyWriterQuery));
+    writerQuery["$or"].push({ writer: oldWriter });
     try { 
       const result = await this._coll.updateOne(
         {
           lockID: this._lockID,
+          $or: writerQuery["$or"],
         },
         {
           $set: {
@@ -203,7 +207,10 @@ export default class RWMutex {
         return;
       }
     } catch (err: unknown) {
-      
+      if (err instanceof MongoError && err.code === DuplicateKeyErrorCode) { 
+        errMsg += ": " + this.overrideWriterSwitchedError;
+        throw new Error(errMsg);
+      }
       if (err instanceof Error) {
         errMsg += `: ${err.message}`;
       }
@@ -227,21 +234,47 @@ export default class RWMutex {
    */
   async conditionalOverrideLockWriter(
     conditional: (oldWriter: string, newWriter: string) => Promise<boolean>,
-    upsert = false): Promise<boolean> { 
-    const mongoLock = await this._coll.findOne({ lockID: this._lockID })
-    if (!mongoLock) {
-      if (!upsert) {
-        return false;
+    upsert = false, timeout = 10000): Promise<boolean> { 
+    const start = Date.now();
+    
+    while (Date.now() - start < timeout) {
+      const mongoLock = await this._coll.findOne({ lockID: this._lockID });
+      if (!mongoLock) {
+        if (!upsert) {
+          return false;
+        }
+        try {
+          await this.tryOverrideLockWriter("", upsert);
+          return true;
+        } catch (err) {
+          if (err instanceof Error) {
+            if (err.message.includes(this.overrideWriterSwitchedError)) { 
+              await timeoutPromise(this._options.sleepTime);
+              continue;
+            }
+          }
+          throw err;
+        }
       }
-      await this.overrideLockWriter(upsert);
-      return true;
+      const conditionalResult = await conditional(mongoLock.writer, this._clientID);
+      if (conditionalResult) {
+        try {
+          await this.tryOverrideLockWriter(mongoLock.writer, upsert);
+          return true;
+        } catch (err) {
+          if (err instanceof Error) {
+            if (err.message.includes(this.overrideWriterSwitchedError)) { 
+              await timeoutPromise(this._options.sleepTime);
+              continue;
+            }
+          }
+          throw err;
+        }
+      } else { 
+        return false
+      }
     }
-    const conditionalResult = await conditional(mongoLock.writer, this._clientID);
-    if (conditionalResult) {
-      await this.overrideLockWriter(upsert);
-      return true;
-    }
-    return false;
+    throw new Error("timeout for overriding lock writer exceeded");
 }
 
   /*

--- a/lib/RWMutex.ts
+++ b/lib/RWMutex.ts
@@ -234,7 +234,7 @@ export default class RWMutex {
    */
   async conditionalOverrideLockWriter(
     conditional: (oldWriter: string, newWriter: string) => Promise<boolean>,
-    upsert = false, timeout = 10000): Promise<boolean> { 
+    upsert = true, timeout = 10000): Promise<boolean> { 
     const start = Date.now();
     
     while (Date.now() - start < timeout) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo-lock-node",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo-lock-node",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ts-node": "^10.9.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo-lock-node",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo-lock-node",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ts-node": "^10.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-lock-node",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "a distributed lock client backed by mongo",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-lock-node",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "a distributed lock client backed by mongo",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
**Jira:**
https://clever.atlassian.net/browse/DING-1991
**Overview:**
The way the override logic was implemented earlier  https://github.com/Clever/mongo-lock-node/pull/26 there was a race condition where we could pass the conditional check for overriding the lock, then the writer could change before overriding it invalidating the conditional check.  This new logic forces the writer to be empty or equal to the writer value we did the comparison check to. If it's not we loop refetching the lock with our lockID and try the comparison again
**Testing:**
Added more to our unit test suite and integration test suite
**Roll Out:**