### PR TITLE
add catalog-info.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,28 +3,29 @@ jobs:
   build:
     working_directory: ~/Clever/mongo-lock-node
     docker:
-    - image: cimg/node:24.0
-    - image: mongo:7.0
+      - image: cimg/node:24.0
+      - image: mongo:7.0
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
-    - run:
-        command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
-        name: Clone ci-scripts
-    - checkout
-    - setup_remote_docker
-    - run:
-        command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-        name: Set up CircleCI artifacts directories
-    - run:
-        name: Set up .npmrc
-        command: |
+      - run:
+          command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
+          name: Clone ci-scripts
+      - checkout
+      - setup_remote_docker
+      - run:
+          command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+          name: Set up CircleCI artifacts directories
+      - run:
+          name: Set up .npmrc
+          command: |
             sed -i.bak s/\${npm_auth_token}/$NPM_TOKEN/ .npmrc_docker
             mv .npmrc_docker .npmrc
-    - run:
-        command: npm install
-        name: npm install
-    - run: make build
-    - run: make test
-    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN ./; fi;
+      - run:
+          command: npm install
+          name: npm install
+      - run: make build
+      - run: make test
+      - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then $HOME/ci-scripts/circleci/npm-publish $NPM_TOKEN ./; fi;
+      - run: $HOME/ci-scripts/circleci/catalog-sync $CATAPULT_URL $CATAPULT_USER $CATAPULT_PASS mongo-lock-node utility

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: mongo-lock-node
+  description: Implements a distributed lock client backed by mongo
+  owner: unknown
+spec:
+  type: unknown
+  lifecycle: production
+  owner: unknown
+  system: Clever


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-7067


# Overview
We want track every single repo in backstage. Currently only repos with an `launch` directory i.e applications are tracked in backstage which this PR aims to change.

To track non applications repo we are adding a catalog-info.yaml file. In this PR I am adding that file via a microplane script so it 
- sets type to "unknown". In 2026 we will do an EWI to update all repos to have a type like "library", "cli", "docs", etc
- owner is determined via README or CODEOWNERS using best effort. In 2026 we will do an EWI to assign owners for unknowns and delete/archive repos that are not in use and have no owners
- description is same as the github repo description.

Note that some repos don't have a circle-ci project associated with them so those repos will get synced onced a week using `catalog-sync-all` worker instead of being synced on every merge.

## Testing
As long as CI is passing it is safe to merge these PRs but make sure to check that circleci is actually one of the checks because a misconfigured ci file ends up not getting reported instead of reporting an error

# Rollout
Infra to merge the PR once CI is passing and approved.
